### PR TITLE
Adds a `babel.config.js` file to enable the `unstable_transformImport…

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,8 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: [
+      ['babel-preset-expo', { unstable_transformImportMeta: true }]
+    ],
+  };
+};


### PR DESCRIPTION
…Meta` polyfill. This is required by the `zustand` library and resolves a build failure when bundling for Hermes on Android.